### PR TITLE
Faster isNotEmpty on collection

### DIFF
--- a/bin/lib/inbuilts.dart
+++ b/bin/lib/inbuilts.dart
@@ -1222,7 +1222,7 @@ $checkValue(i) {
             break;
         case 2:
             var keys = i.keys();
-            if (keys.length != 0)
+            if (keys.isNotEmpty)
                 return true;
             break;
         case -1: return i;


### PR DESCRIPTION
Use isNotEmpty instead (https://www.dartlang.org/guides/language/effective-dart/usage#dont-use-length-to-see-if-a-collection-is-empty)